### PR TITLE
Expose SP signature method in config record

### DIFF
--- a/include/esaml.hrl
+++ b/include/esaml.hrl
@@ -93,6 +93,7 @@
 	certificate :: binary() | undefined,
 	cert_chain = [] :: [binary()],
 	sp_sign_requests = false :: boolean(),
+	sp_sign_method :: xml_dsig:sig_method() | undefined,
 	idp_signs_assertions = true :: boolean(),
 	idp_signs_envelopes = true :: boolean(),
 	idp_signs_logout_requests = true :: boolean(),

--- a/src/esaml_sp.erl
+++ b/src/esaml_sp.erl
@@ -41,7 +41,7 @@ generate_authn_request(IdpURL, SP = #esaml_sp{metadata_uri = MetaURI, consume_ur
                                        issuer = MetaURI,
                                        consumer_location = ConsumeURI}),
     if SP#esaml_sp.sp_sign_requests ->
-        xmerl_dsig:sign(Xml, SP#esaml_sp.key, SP#esaml_sp.certificate);
+        xmerl_dsig:sign(Xml, SP#esaml_sp.key, SP#esaml_sp.certificate, SP#esaml_sp.sp_sign_method);
     true ->
         add_xml_id(Xml)
     end.
@@ -58,7 +58,7 @@ generate_logout_request(IdpURL, NameID, SP = #esaml_sp{metadata_uri = MetaURI}) 
                                        name = NameID,
                                        reason = user}),
     if SP#esaml_sp.sp_sign_requests ->
-        xmerl_dsig:sign(Xml, SP#esaml_sp.key, SP#esaml_sp.certificate);
+        xmerl_dsig:sign(Xml, SP#esaml_sp.key, SP#esaml_sp.certificate, SP#esaml_sp.sp_sign_method);
     true ->
         add_xml_id(Xml)
     end.
@@ -74,7 +74,7 @@ generate_logout_response(IdpURL, Status, SP = #esaml_sp{metadata_uri = MetaURI})
                                        issuer = MetaURI,
                                        status = Status}),
     if SP#esaml_sp.sp_sign_requests ->
-        xmerl_dsig:sign(Xml, SP#esaml_sp.key, SP#esaml_sp.certificate);
+        xmerl_dsig:sign(Xml, SP#esaml_sp.key, SP#esaml_sp.certificate, SP#esaml_sp.sp_sign_method);
     true ->
         add_xml_id(Xml)
     end.

--- a/src/xmerl_dsig.erl
+++ b/src/xmerl_dsig.erl
@@ -22,6 +22,8 @@
 
 -export([verify/1, verify/2, sign/3, strip/1, digest/1]).
 
+-export_type([sig_method/0]).
+
 -include_lib("xmerl/include/xmerl.hrl").
 -include_lib("public_key/include/public_key.hrl").
 
@@ -57,7 +59,7 @@ strip(#xmlElement{content = Kids} = Elem) ->
 sign(ElementIn, PrivateKey = #'RSAPrivateKey'{}, CertBin) when is_binary(CertBin) ->
     sign(ElementIn, PrivateKey, CertBin, "http://www.w3.org/2000/09/xmldsig#rsa-sha1").
 
--spec sign(Element :: #xmlElement{}, PrivateKey :: #'RSAPrivateKey'{}, CertBin :: binary(), SignatureMethod :: sig_method() | sig_method_uri()) -> #xmlElement{}.
+-spec sign(Element :: #xmlElement{}, PrivateKey :: #'RSAPrivateKey'{}, CertBin :: binary(), SignatureMethod :: sig_method() | sig_method_uri() | undefined) -> #xmlElement{}.
 sign(ElementIn, PrivateKey = #'RSAPrivateKey'{}, CertBin, SigMethod) when is_binary(CertBin) ->
     % get rid of any previous signature
     ElementStrip = strip(ElementIn),
@@ -239,6 +241,8 @@ verify(Element) ->
 
 -spec signature_props(atom() | string()) -> {HashFunction :: atom(), DigestMethodUrl :: string(), SignatureMethodUrl :: string()}.
 signature_props("http://www.w3.org/2000/09/xmldsig#rsa-sha1") ->
+    signature_props(rsa_sha1);
+signature_props(undefined) ->
     signature_props(rsa_sha1);
 signature_props(rsa_sha1) ->
     HashFunction = sha,


### PR DESCRIPTION
This change exposes the signature method used by the SP in the #esaml_sp record. This should make it easy to use RSA-SHA256 instead of SHA1.